### PR TITLE
4 | Create Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.env
+venv/
+.idea/
+.git/
+tests/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# Use the Python 3.13 base image
+FROM python:3.13-slim
+LABEL authors="Joseph McDonough"
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    POETRY_VERSION=1.8.2
+
+WORKDIR /app
+
+# Install system dependencies & Poetry
+RUN apt-get update && apt-get install -y curl build-essential && \
+    curl -sSL https://install.python-poetry.org | python3 - && \
+    ln -s /root/.local/bin/poetry /usr/local/bin/poetry && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Copy poetry files and README
+COPY pyproject.toml poetry.lock* README.md /app/
+
+# Configure poetry and install dependencies (only main, no virtualenv)
+RUN poetry config virtualenvs.create false && \
+    poetry install --only main --no-interaction --no-ansi
+
+# Copy app code
+COPY . /app
+
+EXPOSE 8000
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ Current prefix is `v1`
   - **Requests →** string (name)
   - **Returns →** "Hello, (name)!"
 
+# Build Docker Image
+```shell
+docker build -t python-hello-service .
+```
+
 # Setup
 ## Install Poetry
 ```shell

--- a/poetry.lock
+++ b/poetry.lock
@@ -849,5 +849,5 @@ files = [
 
 [metadata]
 lock-version = "2.1"
-python-versions = "^3.13"
-content-hash = "c8bcf26cc6ba2d26bcd45ec181e4fb88c618ebed82b4845b665d96365f0f6115"
+python-versions = ">=3.13"
+content-hash = "e7a6c0647214b3e752c5933fdd207228cf6276bc52c098a80f2c4409e72eb042"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,23 +1,20 @@
-[project]
+[tool.poetry]
 name = "fastapi-skeleton"
 version = "0.1.0"
 description = "FastAPI Skeleton"
-authors = [
-    {name = "Joseph McDonough"}
-]
+authors = ["Joseph McDonough"]
 readme = "README.md"
-requires-python = "^3.13"
-dependencies = [
-    "fastapi (>=0.115.13,<0.116.0)",
-    "uvicorn[standard] (>=0.34.3,<0.35.0)"
-]
+package-mode = false
 
-
-[build-system]
-requires = ["poetry-core>=2.0.0,<3.0.0"]
-build-backend = "poetry.core.masonry.api"
+[tool.poetry.dependencies]
+python = ">=3.13"
+fastapi = ">=0.115.13,<0.116.0"
+uvicorn = { version = ">=0.34.3,<0.35.0", extras = ["standard"] }
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.4.1"
 httpx = "^0.28.1"
 
+[build-system]
+requires = ["poetry-core>=2.0.0,<3.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
### Summary
- `Dockerfile` and `.dockerignore` added to create a python 3.13-slim image
- `README.md` updated to include the command used to build the image
  - `poetry` and `pyproject` had to be updated in order for the build image to work. Had followed the error messages it provided to supply necessary missing/improperly added contents

### Testing
- [x] `docker build -t python-hello-service .` creates an image that appears in Docker Desktop
- [x] Can run the `python-hello-service` image
- [x] Can access the `v1/hello` endpoints from the image
  
Close #4 