### PR TITLE
7 | Templatize Pipeline

### DIFF
--- a/.github/workflows/master-ci.yml
+++ b/.github/workflows/master-ci.yml
@@ -1,4 +1,4 @@
-name: Python CI/CD Pipeline
+name: python-hello-service
 
 on:
   pull_request:

--- a/.github/workflows/master-ci.yml
+++ b/.github/workflows/master-ci.yml
@@ -8,4 +8,4 @@ on:
 
 jobs:
   call-template:
-    uses: jlmOrg/cicd-templates/.github/workflows/python-cicd-template.yml@master
+    uses: jlmOrg/cicd-templates/.github/workflows/python-cicd-template.yml@2-templatize-python-pipeline

--- a/.github/workflows/master-ci.yml
+++ b/.github/workflows/master-ci.yml
@@ -9,3 +9,4 @@ on:
 jobs:
   call-template:
     uses: jlmOrg/cicd-templates/.github/workflows/python-cicd-template.yml@2-templatize-python-pipeline
+

--- a/.github/workflows/master-ci.yml
+++ b/.github/workflows/master-ci.yml
@@ -9,4 +9,3 @@ on:
 jobs:
   call-template:
     uses: jlmOrg/cicd-templates/.github/workflows/python-cicd-template.yml@2-templatize-python-pipeline
-

--- a/.github/workflows/master-ci.yml
+++ b/.github/workflows/master-ci.yml
@@ -1,4 +1,4 @@
-name: CI/CD Pipeline
+name: Python CI/CD Pipeline
 
 on:
   pull_request:
@@ -6,110 +6,6 @@ on:
   push:
     branches: [ master ]
 
-env:
-  IMAGE_NAME: python-hello-service
-
 jobs:
-  docker-build:
-    name: Docker Build
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Build Docker Image
-        run: docker build -t $IMAGE_NAME:${{ github.sha }} .
-
-  tests:
-    name: Run Unit Tests
-    runs-on: ubuntu-latest
-    needs: docker-build
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set Up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.13'
-
-      - name: Install Dependencies
-        run: |
-          curl -sSL https://install.python-poetry.org | python3 -
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
-          poetry config virtualenvs.create false
-          poetry install --with dev --no-interaction --no-ansi
-
-      - name: Run Tests
-        run: |
-          pip install pytest pytest-cov junit-xml
-          pytest --junitxml=test-results.xml
-
-      - name: Upload Test Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-results
-          path: test-results.xml
-
-  test-coverage:
-    name: Test Coverage
-    runs-on: ubuntu-latest
-    needs: docker-build
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set Up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.13'
-
-      - name: Install Dependencies
-        run: |
-          curl -sSL https://install.python-poetry.org | python3 -
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
-          poetry config virtualenvs.create false
-          poetry install --with dev --no-interaction --no-ansi
-          pip install coverage
-
-      - name: Run Coverage
-        run: |
-          coverage run -m pytest
-          coverage report
-          coverage xml
-
-      - name: Upload Coverage Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-report
-          path: coverage.xml
-
-  lint:
-    name: Lint Code
-    runs-on: ubuntu-latest
-    needs: docker-build
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set Up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.13'
-
-      - name: Install Dependencies
-        run: |
-          curl -sSL https://install.python-poetry.org | python3 -
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
-          poetry config virtualenvs.create false
-          poetry install --only main --no-interaction --no-ansi
-          pip install flake8
-
-      - name: Run Flake8
-        run: flake8 --format=checkstyle --output-file=flake8-report.xml . || true
-
-      - name: Upload Flake8 Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: flake8-report
-          path: flake8-report.xml
+  call-template:
+    uses: jlmOrg/cicd-templates/.github/workflows/python-cicd-template.yml@master

--- a/.github/workflows/python-hello-service-ci.yml
+++ b/.github/workflows/python-hello-service-ci.yml
@@ -9,3 +9,6 @@ on:
 jobs:
   call-template:
     uses: jlmOrg/cicd-templates/.github/workflows/python-cicd-template.yml@2-templatize-python-pipeline
+    with:
+      image-name: python-hello-service
+      python-version: '3.13'

--- a/.github/workflows/python-hello-service-ci.yml
+++ b/.github/workflows/python-hello-service-ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   call-template:
-    uses: jlmOrg/cicd-templates/.github/workflows/python-cicd-template.yml@2-templatize-python-pipeline
+    uses: jlmOrg/cicd-templates/.github/workflows/python-cicd-template.yml@master
     with:
       image-name: python-hello-service
       python-version: '3.13'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# python-microservice
-Repository that holds the python backend
+# python-hello-service
+Repository that holds the python backend for the `hello-service`
 
 # Run Service
 ```shell


### PR DESCRIPTION
### Summary
- Referencing the python cicd template present in the [cicd repo](https://github.com/jlmOrg/cicd-templates/blob/f5f7c98de61cc4b3490fd8cea688d0e37db9c85b/.github/workflows/python-cicd-template.yml)

### Testing
- [x] Pipeline runs the same